### PR TITLE
Migrate crate to the 2018 edition (simplified import)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "Set scope-limited values can can be accessed statically"
 version = "1.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
+edition = "2018"
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ macro_rules! environmental {
 		#[allow(non_camel_case_types)]
 		struct $name { __private_field: () }
 
-		thread_local_impl!(static GLOBAL: ::std::cell::RefCell<Option<*mut $t>>
+		$crate::thread_local_impl!(static GLOBAL: ::std::cell::RefCell<Option<*mut $t>>
 			= ::std::cell::RefCell::new(None));
 
 		impl $name {
@@ -194,7 +194,7 @@ macro_rules! environmental {
 		#[allow(non_camel_case_types, dead_code)]
 		struct $name { __private_field: () }
 
-		thread_local_impl!(static GLOBAL: $crate::imp::RefCell<Option<*mut ($t<$($args),*> + 'static)>>
+		$crate::thread_local_impl!(static GLOBAL: $crate::imp::RefCell<Option<*mut ($t<$($args),*> + 'static)>>
 			= $crate::imp::RefCell::new(None));
 
 		impl $name {
@@ -221,7 +221,7 @@ macro_rules! environmental {
 		#[allow(non_camel_case_types, dead_code)]
 		struct $name <H: $traittype> { _private_field: $crate::imp::PhantomData<H> }
 
-		thread_local_impl!(static GLOBAL: $crate::imp::RefCell<Option<*mut ($t<$concretetype> + 'static)>>
+		$crate::thread_local_impl!(static GLOBAL: $crate::imp::RefCell<Option<*mut ($t<$concretetype> + 'static)>>
 			= $crate::imp::RefCell::new(None));
 
 		impl<H: $traittype> $name<H> {


### PR DESCRIPTION
Previously it was required to import not only the `environmental` macro itself, but also `thread_local_impl`:
```rust
use environmental::{environmental, thread_local_impl};
```

I'm not sure if the documentation should be updated. It mentions `#[macro_use] extern crate environmental`, but old imports are still valid.