### PR TITLE
Fix no_std nightly build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "environmental"
 description = "Set scope-limited values can can be accessed statically"
-version = "1.1.2"
+version = "1.1.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@
 //! ```
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(const_fn))]
 
 extern crate alloc;
 
@@ -315,7 +314,7 @@ mod tests {
 	fn simple_works() {
 		environmental!(counter: u32);
 
-		fn stuff() { counter::with(|value| *value += 1); };
+		fn stuff() { counter::with(|value| *value += 1); }
 
 		// declare a stack variable of the same type as our global declaration.
 		let mut local = 41u32;


### PR DESCRIPTION
The `const_fn` feature has been removed from `rustc 1.54.0-nightly (5c0292654 2021-05-11)`

