### PR TITLE
Adds `using_once` function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "environmental"
 description = "Set scope-limited values can can be accessed statically"
-version = "1.1.3"
+version = "1.1.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/local_key.rs
+++ b/src/local_key.rs
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Parity Technologies
+// Copyright 2017-2022 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
`using_once` provides a way to initialize a global once in a recursive call. All other calls to `using_once` will not initialize a new "stack frame" and instead will continue with the already set value.